### PR TITLE
add cawmentators to race rooms

### DIFF
--- a/necrobot/match/cmd_match.py
+++ b/necrobot/match/cmd_match.py
@@ -741,23 +741,28 @@ async def _do_cawmentary_command(cmd: Command, cmd_type: CommandType, add: bool)
     # Add/delete the cawmentary
     if add:
         match.set_cawmentator_id(author_user.user_id)
-        await NEDispatch().publish(event_type='set_cawmentary', match=match)
+    else:
+        match.set_cawmentator_id(None)
 
-        if author_user.member is not None:
-          await cmd.channel.set_permissions(author_user.member, read_messages=True)
+    # Add/remove the cawmentator from the race room
+    if !match.is_self_cawmentated and author_user.member is not None:
+        if add:
+            await cmd.channel.set_permissions(author_user.member,
+                read_messages=True, read_message_history=False, send_messages=False,
+            )
+        else:
+            await cmd.channel.set_permissions(author_user.member, overwrite=None)
 
+    await NEDispatch().publish(event_type='set_cawmentary', match=match)
+
+    # Log success
+    if add:
         await cmd.channel.send(
             'Added {0} as cawmentary for the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name
             )
         )
     else:
-        match.set_cawmentator_id(None)
-        await NEDispatch().publish(event_type='set_cawmentary', match=match)
-
-        if author_user.member is not None:
-          await cmd.channel.set_permissions(author_user.member, overwrite=None)
-
         await cmd.channel.send(
             'Removed {0} as cawmentary from the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name

--- a/necrobot/match/cmd_match.py
+++ b/necrobot/match/cmd_match.py
@@ -742,6 +742,10 @@ async def _do_cawmentary_command(cmd: Command, cmd_type: CommandType, add: bool)
     if add:
         match.set_cawmentator_id(author_user.user_id)
         await NEDispatch().publish(event_type='set_cawmentary', match=match)
+
+        if author_user.member is not None:
+          await cmd.channel.set_permissions(author_user.member, read_messages=True)
+
         await cmd.channel.send(
             'Added {0} as cawmentary for the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name
@@ -750,6 +754,10 @@ async def _do_cawmentary_command(cmd: Command, cmd_type: CommandType, add: bool)
     else:
         match.set_cawmentator_id(None)
         await NEDispatch().publish(event_type='set_cawmentary', match=match)
+
+        if author_user.member is not None:
+          await cmd.channel.set_permissions(author_user.member, overwrite=None)
+
         await cmd.channel.send(
             'Removed {0} as cawmentary from the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name

--- a/necrobot/match/match.py
+++ b/necrobot/match/match.py
@@ -193,6 +193,10 @@ class Match(object):
         return self._cawmentator_id
 
     @property
+    def is_self_cawmentated(self) -> bool:
+        return self._cawmentator_id is not None and (self._cawmentator_id == self._racer_1_id or self._cawmentator_id == self._racer_2_id)
+
+    @property
     def channel_id(self) -> int:
         return self._channel_id
 


### PR DESCRIPTION
Hi! Here's a tiny commit that should make it so cawmentators are added to race rooms, which sounds like a nice feature if you ask me.

I've got some ideas of other stuff I'd like to add (e.g. ping the cawmentator when a confirmed race gets unscheduled) but first I'd like to get some feedback on this:
1. is this a good feature, or do we not want it for some reason, e.g. some sort of privacy reason? (idk) 
2. how's the implementation?
3. is master up-to-date? (don't wanna get any merge conflicts...) I suspect it's not, since I know work has been done on this recently but master is ~3 months old
4. anything else I should do, e.g. tests?

lmk!