### PR TITLE
Revert "add cawmentators to race rooms"

### DIFF
--- a/necrobot/match/cmd_match.py
+++ b/necrobot/match/cmd_match.py
@@ -741,28 +741,15 @@ async def _do_cawmentary_command(cmd: Command, cmd_type: CommandType, add: bool)
     # Add/delete the cawmentary
     if add:
         match.set_cawmentator_id(author_user.user_id)
-    else:
-        match.set_cawmentator_id(None)
-
-    # Add/remove the cawmentator from the race room
-    if !match.is_self_cawmentated and author_user.member is not None:
-        if add:
-            await cmd.channel.set_permissions(author_user.member,
-                read_messages=True, read_message_history=False, send_messages=False,
-            )
-        else:
-            await cmd.channel.set_permissions(author_user.member, overwrite=None)
-
-    await NEDispatch().publish(event_type='set_cawmentary', match=match)
-
-    # Log success
-    if add:
+        await NEDispatch().publish(event_type='set_cawmentary', match=match)
         await cmd.channel.send(
             'Added {0} as cawmentary for the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name
             )
         )
     else:
+        match.set_cawmentator_id(None)
+        await NEDispatch().publish(event_type='set_cawmentary', match=match)
         await cmd.channel.send(
             'Removed {0} as cawmentary from the match {1}.'.format(
                 cmd.author.mention, match.matchroom_name

--- a/necrobot/match/match.py
+++ b/necrobot/match/match.py
@@ -193,10 +193,6 @@ class Match(object):
         return self._cawmentator_id
 
     @property
-    def is_self_cawmentated(self) -> bool:
-        return self._cawmentator_id is not None and (self._cawmentator_id == self._racer_1_id or self._cawmentator_id == self._racer_2_id)
-
-    @property
     def channel_id(self) -> int:
         return self._channel_id
 


### PR DESCRIPTION
Oops, this had a major bug: You don't want to change the permissions for the user in the channel where the command `.cawmentate` was called, but rather in the match channel! Unfortunately it was actually kind of tricky to get something representing the match channel in the squo, so I wound up adding stuff and redoing this commit myself.