### PR TITLE
notify cawmentators when races are unscheduled

### DIFF
--- a/necrobot/condorbot/condormgr.py
+++ b/necrobot/condorbot/condormgr.py
@@ -118,6 +118,9 @@ class CondorMgr(Manager, metaclass=Singleton):
         elif ev.event_type == 'schedule_match':
             asyncio.ensure_future(self._overwrite_schedule_gsheet())
 
+        elif ev.event_type == 'unschedule_match':
+            await self._cawmentator_alert_unschedule(ev.match)
+
         elif ev.event_type == 'set_cawmentary':
             asyncio.ensure_future(self._overwrite_schedule_gsheet())
             if not ev.add:
@@ -263,6 +266,31 @@ class CondorMgr(Manager, metaclass=Singleton):
             wks_id=0,                                   # TODO: hack
             sheet_type=sheetlib.SheetType.MATCHUP
         )
+
+    @staticmethod
+    async def _cawmentator_alert_unschedule(match: Match):
+        """PM an alert to the match cawmentator, if any, that the previously scheduled match has been unscheduled
+
+        Parameters
+        ----------
+        match: Match
+        """
+        # PM a cawmentator alert
+        cawmentator = await match.get_cawmentator()
+        if cawmentator is None:
+            return
+
+        alert_format_str = 'A race you\'re scheduled to cawmentate has been unscheduled. ' \
+                           '(**{racer_1}** - **{racer_2}**)\n' \
+                           '(Note: You are still the cawmentator for this race. If the racers ' \
+                           'reschedule to a time that doesn\'t work for you, use .uncawmentate)\n\n'
+
+        alert_text = alert_format_str.format(
+            racer_1=match.racer_1.display_name,
+            racer_2=match.racer_2.display_name
+        )
+
+        await cawmentator.member.send(alert_text)
 
     @staticmethod
     async def _cawmentator_alert(match: Match):

--- a/necrobot/match/cmd_match.py
+++ b/necrobot/match/cmd_match.py
@@ -275,6 +275,7 @@ class Unconfirm(CommandType):
             else:
                 await cmd.channel.send(
                     'The match has been unscheduled. Please `.suggest` a new time when one has been agreed upon.')
+                await NEDispatch().publish('unschedule_match', match=match)
         # if match was not scheduled
         else:
             await cmd.channel.send(


### PR DESCRIPTION
o/

I can see one problem(?) with this:
* A and B have a scheduled race, C is the cawmentator
* Then, A and B unschedule.
* C gets a notification that they unscheduled (good!)
* A and B reschedule. C does not get a notification that the race has been re-scheduled (bad...?)

afaict it would be a much more involved changed to make that scenario work differently, so I didn't tackle it.

lmk what you think!